### PR TITLE
Cmake include directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
 before_install:
     - sudo add-apt-repository ppa:apokluda/boost1.53 --yes
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test --yes # libstdc++-4.8
-    - sudo add-apt-repository ppa:george-edison55/cmake-3.x --yes
     - if [ "${CXX}" == "clang++" ]; then sudo add-apt-repository --yes ppa:h-rayflood/llvm; fi # clang++-3.2
     - sudo apt-get update
 
@@ -24,7 +23,7 @@ install:
     - sudo apt-get install libboost-system1.53-dev
     - sudo apt-get install libboost-regex1.53-dev
     - sudo apt-get install libboost-filesystem1.53-dev
-    - sudo apt-get install cmake
+    - wget -q0- http://www.cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz | tar xvz && sudo cp -fR cmake-3.3.2-Linux-x86_64/* /usr
 
 before_script:
     # update compilers

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
     - sudo apt-get install libboost-system1.53-dev
     - sudo apt-get install libboost-regex1.53-dev
     - sudo apt-get install libboost-filesystem1.53-dev
-    - wget -q0- http://www.cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz | tar xvz && sudo cp -fR cmake-3.3.2-Linux-x86_64/* /usr
+    - wget -qO- http://www.cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz | tar xvz && sudo cp -fR cmake-3.3.2-Linux-x86_64/* /usr
 
 before_script:
     # update compilers

--- a/README.rst
+++ b/README.rst
@@ -53,13 +53,13 @@ Building with CMake
 ~~~~~~~~~~~~~~~~~~~
 
 To build the libraries and run the tests with CMake, you will need to
-have CMake version 2.8.10 or higher installed appropriately in your
+have CMake version 3.0 or higher installed appropriately in your
 system.
 
 ::
 
     $ cmake --version
-    cmake version 2.8.10
+    cmake version 3.2.2
 
 Inside the cpp-netlib directory, you can issue the following statements to
 configure and generate the Makefiles, and build the tests::


### PR DESCRIPTION
This uses cmake 3 for travis-ci. Travis uses Ubuntu 12.04 LTS and the ppa you added doesn't have cmake 3 packages for this version. Travis will now fetch the binary dist of cmake 3.3.2 and _installs_ it in /usr

I also updated the README to reflect the requirement of CMake >= 3.0
